### PR TITLE
Bump ring to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ bytes        = "^0.4"
 clap         = "2.33.0"
 derive_more  = "^0.13"
 hex          = "^0.3"
-ring         = "^0.16"
+ring         = "^0.17"
 uuid         = { version = "^0.7", features = ["v4"] }
 xml-rs       = "0.8.0"


### PR DESCRIPTION
ring 0.17 supports more architectures and has many other desirable improvements, including newer assembly from BoringSSL that moves constants to the read-only data and has CET support.